### PR TITLE
Introduce logging

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401, F405
+ignore = E203, E266, E501, W503, F403, F401, F405, W292
 max-line-length = 90
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/notoma/cli.py
+++ b/notoma/cli.py
@@ -12,6 +12,7 @@ from .core import (
     draft_pages,
 )
 from . import __version__
+from .logging import logger, set_log_level_from_option
 
 """
 `cli` Module only has thin wrappers around Notoma Python API
@@ -27,12 +28,16 @@ Run `notoma` for the help article on how to use the CLI.
     help="""Build your staticg gen blog with Notion.
     Notoma converts Notion database of blog posts into a directory of .md files."""
 )
-def runner() -> None:
+@click.option("--debug", is_flag=True, default=False, help="Enable debug output.")
+def runner(debug: bool = False) -> None:
+    logger.info("Notoma CLI invoked.")
+    set_log_level_from_option(logger, debug)
     pass
 
 
 @runner.command(help="Print Notoma version.")
 def version():
+    logger.info(f"Printing Notoma version: {__version__}")
     click.echo(f"Notoma {__version__}")
 
 
@@ -54,11 +59,9 @@ def version():
 )
 @click.option("--token_v2", "-t", help="Notion auth token from the cookie.")
 @click.option("--verbose", is_flag=True, default=False, help="Verbose output.")
-@click.option("--debug", is_flag=True, default=False, help="Enable debug output.")
 def convert(
     dest: str,
     drafts: str,
-    debug: bool = False,
     verbose: bool = False,
     token_v2: str = None,
     notion_url: str = None,
@@ -85,6 +88,8 @@ def watch() -> None:
     """
     Watch for updates in the Notion Blog and update the Markdown posts
     """
+    logger.info("Invoking Watch command.")
+    logger.error("Watch is not implemented.")
     raise NotImplementedError("Watcher is not implemented yet.")
 
 
@@ -102,6 +107,7 @@ def __convert_pages(
     "Convert a bunch of pages with a nice progress bar."
 
     if verbose:
+        logger.info(f"{len(pages)} pages to process.")
         click.echo(f"{len(pages)} pages to process.")
 
     with click.progressbar(pages) as bar:
@@ -134,3 +140,7 @@ def __validate_config(config: Config) -> None:
         for e in errors:
             click.echo(e)
         raise click.Abort()
+
+
+def __log(message: str) -> None:
+    "Logs a message"

--- a/notoma/logging.py
+++ b/notoma/logging.py
@@ -1,21 +1,28 @@
 import logging
 
-FMT = "%(asctime)s %(name)s [%(levelname)s]: %(message)s -- %(module)s.%(funcName)s %(filename)s:%(lineno)s"
+LOG_FMT = "%(asctime)s %(name)s [%(levelname)s]: %(message)s -- %(module)s.%(funcName)s %(filename)s:%(lineno)s"
 LEVEL = logging.DEBUG
 LOG_FNAME = ".notoma.log"
-HANDLER = logging.FileHandler(LOG_FNAME, "w+")
+
+LOG_FILE_HANDLER = logging.FileHandler(LOG_FNAME, "w+")
+LOG_NULL_HANDLER = logging.NullHandler()
 
 
-def get_logger(level=LEVEL, handler=HANDLER, format=FMT):
-    "Returns a customized logger. Defaults to logging INFO to `.notoma.log`."
+def get_logger(level=LEVEL, handler=LOG_NULL_HANDLER, format=LOG_FMT):
+    "Returns a customized logger. Defaults to logging INFO to NullHandler."
     handler.setFormatter(logging.Formatter(format))
     logger = logging.getLogger(__name__)
     logger.setLevel(LEVEL)
     logger.addHandler(handler)
+    logger.info(f"New Notoma logger initialized with handler type: {type(handler)}")
     return logger
 
 
-def set_log_level_from_option(logger: logging.Logger, debug: bool = False) -> None:
+def toggle_debug(logger: logging.Logger, debug: bool = False) -> None:
+    """
+    Sets log level to INFO or DEBUG depending on a boolean flag in place,
+    and returns None.
+    """
     if debug:
         logger.info("Setting log level to DEBUG")
         logger.setLevel(logging.DEBUG)  # debug
@@ -23,7 +30,3 @@ def set_log_level_from_option(logger: logging.Logger, debug: bool = False) -> No
         logger.info("Setting log level to INFO")
         logger.setLevel(logging.INFO)  # info
     return logger
-
-
-logger = get_logger()
-logger.info("Initializing logger for Notoma.")

--- a/notoma/logging.py
+++ b/notoma/logging.py
@@ -1,0 +1,29 @@
+import logging
+
+FMT = "%(asctime)s %(name)s [%(levelname)s]: %(message)s -- %(module)s.%(funcName)s %(filename)s:%(lineno)s"
+LEVEL = logging.DEBUG
+LOG_FNAME = ".notoma.log"
+HANDLER = logging.FileHandler(LOG_FNAME, "w+")
+
+
+def get_logger(level=LEVEL, handler=HANDLER, format=FMT):
+    "Returns a customized logger. Defaults to logging INFO to `.notoma.log`."
+    handler.setFormatter(logging.Formatter(format))
+    logger = logging.getLogger(__name__)
+    logger.setLevel(LEVEL)
+    logger.addHandler(handler)
+    return logger
+
+
+def set_log_level_from_option(logger: logging.Logger, debug: bool = False) -> None:
+    if debug:
+        logger.info("Setting log level to DEBUG")
+        logger.setLevel(logging.DEBUG)  # debug
+    else:
+        logger.info("Setting log level to INFO")
+        logger.setLevel(logging.INFO)  # info
+    return logger
+
+
+logger = get_logger()
+logger.info("Initializing logger for Notoma.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ include = ["LICENSE", "CONTRIBUTING.md", "README.md", ".env.sample"]
 notoma-dev = "notoma.dev:cli"
 notoma = "notoma.cli:runner"
 
-
 [tool.poetry.dependencies]
 python = ">=3.6"
 notion = ">=0.0.25"
@@ -41,7 +40,6 @@ jupyter_contrib_nbextensions = "*"
 nbconvert = "*"
 nbformat = "*"
 nbexec = "*"
-twine = "*"
 
 
 [tool.black]
@@ -60,6 +58,7 @@ exclude = '''
   | dist
 )/
 '''
+
 [build-system]
 requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Closes #16.

- [ ] Introduce basic configurable logging
- [ ] Switch --verbose and --debug to logging everywhere
- [ ] Add more logging to command invocations: commands and their options should be logged.
- [ ] Refactor common options like `--debug` should be united into one decorator. This can be extracted into a separate PR though. 